### PR TITLE
Added 'enableEndorse' for groups based on the 'Show badge' option from admin group settings in the post upvoters file

### DIFF
--- a/public/openapi/write/posts/pid/voters.yaml
+++ b/public/openapi/write/posts/pid/voters.yaml
@@ -36,4 +36,14 @@ get:
                     type: array
                   downvoters:
                     type: array
+                  userGroups:
+                    type: array
+                  # used these to show edit changes in the Network page of devtool
+                  userData:
+                    type: array
+                  groupData:
+                    type: array
+                  enableEndorse:
+                    type: boolean
+                    
 

--- a/public/src/admin/manage/group.js
+++ b/public/src/admin/manage/group.js
@@ -98,7 +98,13 @@ define('admin/manage/group', [
 			});
 		});
 
+		$('#group-userTitleEnabled').on('change', function() {
+			console.log("test - adjusting show badge settings");
+		});
+		
 		$('#save').on('click', function () {
+			console.log("test - save admin changes on group settings");
+			
 			api.put(`/groups/${slugify(groupName)}`, {
 				name: $('#change-group-name').val(),
 				userTitle: changeGroupUserTitle.val(),

--- a/public/src/client/account/edit.js
+++ b/public/src/client/account/edit.js
@@ -159,6 +159,7 @@ define('forum/account/edit', [
 				$('[component="group/badge/list"] [component="group/toggle/show"]').removeClass('hidden');
 				$('[component="group/badge/list"] [component="group/toggle/hide"]').addClass('hidden');
 				$('[component="group/badge/list"] [component="group/badge/item"]').attr('data-selected', 'false');
+				console.log("goodmorning 240921");
 			}
 			const groupEl = $(this).parents('[component="group/badge/item"]');
 			groupEl.attr('data-selected', 'true');

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -335,6 +335,30 @@ postsAPI.getVoters = async function (caller, data) {
 		user.getUsersFields(downvoteUids, ['username', 'userslug', 'picture']),
 	]);
 
+	// ===========================
+	// let groupNames = await db.getSortedSetRevRange(set, 0, -1);
+	// groupNames = groupNames[0];
+	console.log("all groups:", upvoters);
+
+	let userGroups;
+	userGroups = await groups.getUserGroups ([upvoteUids[0]])
+
+	const [userData, groupData] = await Promise.all([
+		user.getUsersData(upvoteUids),
+		groups.getUserGroupsFromSet('groups:createtime', upvoteUids),
+	]);
+
+	// inspired by Victor's code 
+	let enableEndorse = false; 
+
+	for (const user of userData) {
+		const groupfields = await groups.getGroupsFields(user.groupTitleArray, ['userTitleEnabled']);
+		if (groupfields[0]) {
+			enableEndorse = true;
+		}
+	}
+	// ===========================
+
 	return {
 		upvoteCount: upvoters.length,
 		downvoteCount: downvoters.length,
@@ -342,6 +366,10 @@ postsAPI.getVoters = async function (caller, data) {
 		showDownvotes: showDownvotes,
 		upvoters: upvoters,
 		downvoters: downvoters,
+		userGroups: userGroups,
+		userData: userData,
+		groupData: groupData,
+		enableEndorse: enableEndorse // inspired by Victor's code 
 	};
 };
 


### PR DESCRIPTION
Backend edits on allowing admin to select specific groups (other than the default admin group) whose posts should be endorsed. Relevant to #5, additional customizable feature that could be combined with #12 .