### PR TITLE
Added endorseEnabled for admin group settings

### DIFF
--- a/public/language/ar/admin/manage/groups.json
+++ b/public/language/ar/admin/manage/groups.json
@@ -32,6 +32,7 @@
 	"edit.label-color": "Group Label Color",
 	"edit.text-color": "Group Text Color",
 	"edit.show-badge": "Show Badge",
+	"edit.show-endorse": "Allow Endorse",
 	"edit.private-details": "If enabled, joining of groups requires approval from a group owner.",
 	"edit.private-override": "Warning: Private groups is disabled at system level, which overrides this option.",
 	"edit.disable-join": "Disable join requests",

--- a/public/language/en-GB/groups.json
+++ b/public/language/en-GB/groups.json
@@ -49,6 +49,7 @@
 	"details.change-text-colour": "Change Text Colour",
 	"details.badge-text": "Badge Text",
 	"details.userTitleEnabled": "Show Badge",
+	"details.endorseEnabled": "Allow Endorse",
 	"details.private-help": "If enabled, joining of groups requires approval from a group owner",
 	"details.hidden": "Hidden",
 	"details.hidden-help": "If enabled, this group will not be found in the groups listing, and users will have to be invited manually",

--- a/public/openapi/components/schemas/GroupObject.yaml
+++ b/public/openapi/components/schemas/GroupObject.yaml
@@ -19,6 +19,8 @@ GroupFullObject:
       description: Same as userTitle but with translation tokens escaped, used to display raw userTitle in group management
     userTitleEnabled:
       type: number
+    endorseEnabled:
+      type: number
     description:
       type: string
       description: The group description
@@ -169,6 +171,8 @@ GroupDataObject:
       type: number
       description: Same as userTitle but with translation tokens escaped, used to display raw userTitle in group management
     userTitleEnabled:
+      type: number
+    endorseEnabled:
       type: number
     description:
       type: string

--- a/public/openapi/read/admin/manage/groups.yaml
+++ b/public/openapi/read/admin/manage/groups.yaml
@@ -50,6 +50,8 @@ get:
                           type: string
                         userTitleEnabled:
                           type: number
+                        endorseEnabled:
+                          type: number
                         disableJoinRequests:
                           type: number
                         disableLeave:
@@ -88,6 +90,7 @@ get:
                         - cover:url
                         - cover:position
                         - userTitleEnabled
+                        - endorseEnabled
                         - disableJoinRequests
                         - disableLeave
                         - nameEncoded

--- a/public/openapi/read/groups.yaml
+++ b/public/openapi/read/groups.yaml
@@ -42,6 +42,8 @@ get:
                           type: number
                         userTitleEnabled:
                           type: number
+                        endorseEnabled:
+                          type: number
                         disableJoinRequests:
                           type: number
                         disableLeave:

--- a/public/src/admin/manage/group.js
+++ b/public/src/admin/manage/group.js
@@ -107,6 +107,7 @@ define('admin/manage/group', [
 				labelColor: changeGroupLabelColor.val(),
 				textColor: changeGroupTextColor.val(),
 				userTitleEnabled: $('#group-userTitleEnabled').is(':checked'),
+				endorseEnabled: $('#group-endorseEnabled').is(':checked'),
 				private: $('#group-private').is(':checked'),
 				hidden: $('#group-hidden').is(':checked'),
 				memberPostCids: $('#memberPostCids').val(),

--- a/src/groups/create.js
+++ b/src/groups/create.js
@@ -34,6 +34,7 @@ module.exports = function (Groups) {
 			createtime: timestamp,
 			userTitle: data.userTitle || data.name,
 			userTitleEnabled: parseInt(data.userTitleEnabled, 10) === 1 ? 1 : 0,
+			endorseEnabled: parseInt(data.endorseEnabled, 10) === 1 ? 1 : 0,
 			description: data.description || '',
 			memberCount: memberCount,
 			hidden: isHidden ? 1 : 0,

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -10,7 +10,7 @@ const translator = require('../translator');
 
 const intFields = [
 	'createtime', 'memberCount', 'hidden', 'system', 'private',
-	'userTitleEnabled', 'disableJoinRequests', 'disableLeave',
+	'userTitleEnabled', 'disableJoinRequests', 'disableLeave', 'endorseEnabled'
 ];
 
 module.exports = function (Groups) {
@@ -71,6 +71,7 @@ function modifyGroup(group, fields) {
 
 		escapeGroupData(group);
 		group.userTitleEnabled = ([null, undefined].includes(group.userTitleEnabled)) ? 1 : group.userTitleEnabled;
+		group.endorseEnabled = ([null, undefined].includes(group.endorseEnabled)) ? 1 : group.endorseEnabled;
 		group.labelColor = validator.escape(String(group.labelColor || '#000000'));
 		group.textColor = validator.escape(String(group.textColor || '#ffffff'));
 		group.icon = validator.escape(String(group.icon || ''));

--- a/src/groups/data.js
+++ b/src/groups/data.js
@@ -10,7 +10,7 @@ const translator = require('../translator');
 
 const intFields = [
 	'createtime', 'memberCount', 'hidden', 'system', 'private',
-	'userTitleEnabled', 'disableJoinRequests', 'disableLeave', 'endorseEnabled'
+	'userTitleEnabled', 'disableJoinRequests', 'disableLeave', 'endorseEnabled',
 ];
 
 module.exports = function (Groups) {

--- a/src/groups/update.js
+++ b/src/groups/update.js
@@ -26,7 +26,7 @@ module.exports = function (Groups) {
 
 		// Cast some values as bool (if not boolean already)
 		// 'true' and '1' = true, everything else false
-		['userTitleEnabled', 'private', 'hidden', 'disableJoinRequests', 'disableLeave'].forEach((prop) => {
+		['userTitleEnabled', 'private', 'hidden', 'disableJoinRequests', 'disableLeave', 'endorseEnabled'].forEach((prop) => {
 			if (values.hasOwnProperty(prop) && typeof values[prop] !== 'boolean') {
 				values[prop] = values[prop] === 'true' || parseInt(values[prop], 10) === 1;
 			}
@@ -45,6 +45,10 @@ module.exports = function (Groups) {
 
 		if (values.hasOwnProperty('userTitleEnabled')) {
 			payload.userTitleEnabled = values.userTitleEnabled ? '1' : '0';
+		}
+
+		if (values.hasOwnProperty('endorseEnabled')) {
+			payload.endorseEnabled = values.endorseEnabled ? '1' : '0';
 		}
 
 		if (values.hasOwnProperty('hidden')) {

--- a/src/views/admin/manage/group.tpl
+++ b/src/views/admin/manage/group.tpl
@@ -85,6 +85,13 @@
 
 				<div class="mb-3">
 					<div class="form-check form-switch">
+						<input class="form-check-input" id="group-endorseEnabled" name="endorseEnabled" data-property type="checkbox"{{{ if group.endorseEnabled }}} checked{{{ end }}}>
+						<label class="form-check-label" for="group-endorseEnabled">Allow Endorse</label>
+					</div>
+				</div>
+
+				<div class="mb-3">
+					<div class="form-check form-switch">
 						<input class="form-check-input" id="group-private" name="private" data-property type="checkbox"{{{ if group.private }}} checked{{{ end }}}>
 						<label class="form-check-label" for="group-private">[[groups:details.private]]</label>
 					</div>


### PR DESCRIPTION
Added endorseEnabled as a new field for the Groups module, and added checkbox to admin group settings. 
![image](https://github.com/user-attachments/assets/77a1f450-a89e-4ab0-8ad0-5535b9330425)

Relevant updated files include:
- `src/groups/data.js` : add the field; set null and undefined values to default (1=true)
- `src/groups/create.js` : add the new field to group data
- `src/groups/update.js` : cast values as bool
- `public/src/admin/manage/group.js` : include endorsement checkbox value when admin updates group settings
- `src/views/admin/manage/group.tpl` : allow checkbox to show up at frontend
- `public/openapi/read/admin/manage/groups.yaml` : update variables with types
- `public/openapi/components/schemas/GroupObject.yaml` : update variables with types
- `public/openapi/read/groups.yaml` : update variables with types

![image](https://github.com/user-attachments/assets/c30d7aad-b420-45cc-8c29-5dce593614d4)

Resolves #16 

