### PR TITLE
Search category topics based on main post content and display content snippets when matched.

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,4 +1,4 @@
 reporter: dot
 timeout: 25000
 exit: true
-bail: true
+bail: false

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -1,6 +1,6 @@
 TopicObject:
   allOf:
-    - $ref: "#/TopicObjectSlim"
+    - $ref: '#/TopicObjectSlim'
     - type: object
       properties:
         lastposttime:
@@ -45,8 +45,7 @@ TopicObject:
               type: string
             userslug:
               type: string
-              description:
-                An URL-safe variant of the username (i.e. lower-cased, spaces
+              description: An URL-safe variant of the username (i.e. lower-cased, spaces
                 removed, etc.)
             reputation:
               type: number
@@ -64,14 +63,12 @@ TopicObject:
               type: string
             icon:text:
               type: string
-              description:
-                A single-letter representation of a username. This is used in the
+              description: A single-letter representation of a username. This is used in the
                 auto-generated icon given to users without
                 an avatar
             icon:bgColor:
               type: string
-              description:
-                A six-character hexadecimal colour code assigned to the user. This
+              description: A six-character hexadecimal colour code assigned to the user. This
                 value is used in conjunction with
                 `icon:text` for the user's auto-generated
                 icon
@@ -120,22 +117,19 @@ TopicObject:
                   description: A friendly name for a given user account
                 userslug:
                   type: string
-                  description:
-                    An URL-safe variant of the username (i.e. lower-cased, spaces
+                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
                     removed, etc.)
                 picture:
                   nullable: true
                   type: string
                 icon:text:
                   type: string
-                  description:
-                    A single-letter representation of a username. This is used in the
+                  description: A single-letter representation of a username. This is used in the
                     auto-generated icon given to users
                     without an avatar
                 icon:bgColor:
                   type: string
-                  description:
-                    A six-character hexadecimal colour code assigned to the user. This
+                  description: A six-character hexadecimal colour code assigned to the user. This
                     value is used in conjunction with
                     `icon:text` for the user's
                     auto-generated icon
@@ -237,8 +231,7 @@ TopicObjectSlim:
           type: number
         pinned:
           type: number
-          description:
-            Whether or not this particular topic is pinned to the top of the
+          description: Whether or not this particular topic is pinned to the top of the
             category
         timestamp:
           type: number

--- a/public/openapi/components/schemas/TopicObject.yaml
+++ b/public/openapi/components/schemas/TopicObject.yaml
@@ -1,6 +1,6 @@
 TopicObject:
   allOf:
-    - $ref: '#/TopicObjectSlim'
+    - $ref: "#/TopicObjectSlim"
     - type: object
       properties:
         lastposttime:
@@ -45,7 +45,8 @@ TopicObject:
               type: string
             userslug:
               type: string
-              description: An URL-safe variant of the username (i.e. lower-cased, spaces
+              description:
+                An URL-safe variant of the username (i.e. lower-cased, spaces
                 removed, etc.)
             reputation:
               type: number
@@ -63,12 +64,14 @@ TopicObject:
               type: string
             icon:text:
               type: string
-              description: A single-letter representation of a username. This is used in the
+              description:
+                A single-letter representation of a username. This is used in the
                 auto-generated icon given to users without
                 an avatar
             icon:bgColor:
               type: string
-              description: A six-character hexadecimal colour code assigned to the user. This
+              description:
+                A six-character hexadecimal colour code assigned to the user. This
                 value is used in conjunction with
                 `icon:text` for the user's auto-generated
                 icon
@@ -117,19 +120,22 @@ TopicObject:
                   description: A friendly name for a given user account
                 userslug:
                   type: string
-                  description: An URL-safe variant of the username (i.e. lower-cased, spaces
+                  description:
+                    An URL-safe variant of the username (i.e. lower-cased, spaces
                     removed, etc.)
                 picture:
                   nullable: true
                   type: string
                 icon:text:
                   type: string
-                  description: A single-letter representation of a username. This is used in the
+                  description:
+                    A single-letter representation of a username. This is used in the
                     auto-generated icon given to users
                     without an avatar
                 icon:bgColor:
                   type: string
-                  description: A six-character hexadecimal colour code assigned to the user. This
+                  description:
+                    A six-character hexadecimal colour code assigned to the user. This
                     value is used in conjunction with
                     `icon:text` for the user's
                     auto-generated icon
@@ -176,6 +182,10 @@ TopicObject:
         tid:
           type: number
           description: A topic identifier
+        content:
+          type: string
+          nullable: true
+          description: Content of the original topic post for showing search previews.
         thumb:
           type: string
         pinExpiry:
@@ -227,7 +237,8 @@ TopicObjectSlim:
           type: number
         pinned:
           type: number
-          description: Whether or not this particular topic is pinned to the top of the
+          description:
+            Whether or not this particular topic is pinned to the top of the
             category
         timestamp:
           type: number

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -125,26 +125,43 @@ define('forum/category', [
 
 		searchEl.on('keyup', function () {
 			const searchTerm = searchEl.val().toLowerCase();
+
 			topicEls.each(function () {
 				const topicEl = $(this);
 				const titleEl = topicEl.find('[component="topic/header"] a');
 				const title = titleEl.text().toLowerCase();
-				const isMatch = title.indexOf(searchTerm) !== -1;
-				console.log(`Title: ${title}\n ${isMatch ? 'Hidden' : 'Visible'}\n`);
+				const titleMatch = title.indexOf(searchTerm) !== -1;
+				const contentEl = topicEl.find('[component="topic/hidden-content"]');
+				const content = contentEl.text().toLowerCase();
+				const contentIdx = content.indexOf(searchTerm)
+				const hasMatch = (titleMatch || (contentIdx !== -1))
+				const searchContentEl = topicEl.find('[component="topic/search-content"]');
 
-				topicEl.toggleClass('hidden', !isMatch);
+				topicEl.toggleClass('hidden', !hasMatch);
+
+				// Use topic/search-content placeholder to display the 100 character preview around the search term. 
+				// Only do this if the search is more than 2 characters
+				if (contentIdx !== -1 && searchTerm.length >= 2) {
+					const start = Math.max(0, contentIdx - 50);
+					const end = Math.min(content.length, contentIdx + searchTerm.length + 50);
+					const snippet = content.substring(start, end);
+
+					const highlightedSnippet = snippet.replace(new RegExp(`(${searchTerm})`, 'gi'), '<strong class="highlight">$1</strong>');
+					searchContentEl.html(`...${highlightedSnippet}...`);
+				} else {
+					searchContentEl.html("");
+				}
 			});
 
+			// Show the alert for no matches if there are no matched topics, otherwise keep it hidden.
 			const visibleTopics = topicEls.filter(':not(.hidden)');
+			const alertComponent = $('[component="category/topic/no-matches"]')
 			if (visibleTopics.length === 0) {
-				if ($('[component="category/topic/no-matches"]').length === 0) {
-					$(`<div component="category/topic/no-matches" class="alert alert-info">No topics match the search term ${searchTerm}.</div>`)
-						.insertAfter('[component="category/topic"]:last');
-				} else {
-					$('[component="category/topic/no-matches"]').removeClass('hidden');
-				}
+				alertComponent.removeClass('hidden');
+				alertComponent.html(`No topics match the search term ${searchTerm}.`);
 			} else {
-				$('[component="category/topic/no-matches"]').addClass('hidden');
+				alertComponent.addClass('hidden');
+				alertComponent.html("");
 			}
 		});
 	}

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -133,13 +133,13 @@ define('forum/category', [
 				const titleMatch = title.indexOf(searchTerm) !== -1;
 				const contentEl = topicEl.find('[component="topic/hidden-content"]');
 				const content = contentEl.text().toLowerCase();
-				const contentIdx = content.indexOf(searchTerm)
-				const hasMatch = (titleMatch || (contentIdx !== -1))
+				const contentIdx = content.indexOf(searchTerm);
+				const hasMatch = (titleMatch || (contentIdx !== -1));
 				const searchContentEl = topicEl.find('[component="topic/search-content"]');
 
 				topicEl.toggleClass('hidden', !hasMatch);
 
-				// Use topic/search-content placeholder to display the 100 character preview around the search term. 
+				// Use topic/search-content placeholder to display the 100 character preview around the search term.
 				// Only do this if the search is more than 2 characters
 				if (contentIdx !== -1 && searchTerm.length >= 2) {
 					const start = Math.max(0, contentIdx - 50);
@@ -149,19 +149,19 @@ define('forum/category', [
 					const highlightedSnippet = snippet.replace(new RegExp(`(${searchTerm})`, 'gi'), '<strong class="highlight">$1</strong>');
 					searchContentEl.html(`...${highlightedSnippet}...`);
 				} else {
-					searchContentEl.html("");
+					searchContentEl.html('');
 				}
 			});
 
 			// Show the alert for no matches if there are no matched topics, otherwise keep it hidden.
 			const visibleTopics = topicEls.filter(':not(.hidden)');
-			const alertComponent = $('[component="category/topic/no-matches"]')
+			const alertComponent = $('[component="category/topic/no-matches"]');
 			if (visibleTopics.length === 0) {
 				alertComponent.removeClass('hidden');
 				alertComponent.html(`No topics match the search term ${searchTerm}.`);
 			} else {
 				alertComponent.addClass('hidden');
-				alertComponent.html("");
+				alertComponent.html('');
 			}
 		});
 	}

--- a/public/src/client/category.js
+++ b/public/src/client/category.js
@@ -137,6 +137,7 @@ define('forum/category', [
 				const hasMatch = (titleMatch || (contentIdx !== -1));
 				const searchContentEl = topicEl.find('[component="topic/search-content"]');
 
+				// Hide topics that don't match the search term in their title or their content
 				topicEl.toggleClass('hidden', !hasMatch);
 
 				// Use topic/search-content placeholder to display the 100 character preview around the search term.
@@ -146,7 +147,8 @@ define('forum/category', [
 					const end = Math.min(content.length, contentIdx + searchTerm.length + 50);
 					const snippet = content.substring(start, end);
 
-					const highlightedSnippet = snippet.replace(new RegExp(`(${searchTerm})`, 'gi'), '<strong class="highlight">$1</strong>');
+					// Make the search term come out bold in the search preview
+					const highlightedSnippet = snippet.replace(searchTerm, `<strong>${searchTerm}</strong>`);
 					searchContentEl.html(`...${highlightedSnippet}...`);
 				} else {
 					searchContentEl.html('');

--- a/src/categories/topics.js
+++ b/src/categories/topics.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const sanitizeHtml = require('sanitize-html');
 const db = require('../database');
 const topics = require('../topics');
 const plugins = require('../plugins');
@@ -9,7 +10,6 @@ const user = require('../user');
 const notifications = require('../notifications');
 const translator = require('../translator');
 const batch = require('../batch');
-const sanitizeHtml = require('sanitize-html');
 
 module.exports = function (Categories) {
 	Categories.getCategoryTopics = async function (data) {
@@ -17,14 +17,14 @@ module.exports = function (Categories) {
 		const tids = await Categories.getTopicIds(results);
 		let topicsData = await topics.getTopicsByTids(tids, data.uid);
 		topicsData = await user.blocks.filter(data.uid, topicsData);
-			
+
 		// Add actual post content to the topicsData to show search previews
 		const mainPosts = await topics.getMainPosts(tids, data.uid);
 		topicsData.forEach((topic, idx) => {
 			// Clean all html, allowing no tags or attributes
 			topic.content = sanitizeHtml(mainPosts[idx].content, {
 				allowedTags: [],
-				allowedAttributes: {}
+				allowedAttributes: {},
 			});
 		});
 

--- a/test/categories.js
+++ b/test/categories.js
@@ -136,6 +136,41 @@ describe('Categories', () => {
 				done();
 			});
 		});
+
+		// Tests for adding content to the topics. Ensure that the content field exists.
+		it('should return topics that have a content field', (done) => {
+			Categories.getCategoryTopics({
+				cid: categoryObj.cid,
+				start: 0,
+				stop: 10,
+				uid: 0,
+				sort: 'oldest_to_newest',
+			}, (err, result) => {
+				assert.equal(err, null);
+				assert(Array.isArray(result.topics));
+				assert(result.topics.every(topic => topic instanceof Object && topic.hasOwnProperty('content')));
+
+				done();
+			});
+		});
+
+		// Tests for adding content to the topics. Ensure that the content field has no html tags.
+		it('should return topics that have a content field with no html tags', (done) => {
+			Categories.getCategoryTopics({
+				cid: categoryObj.cid,
+				start: 0,
+				stop: 10,
+				uid: 0,
+				sort: 'oldest_to_newest',
+			}, (err, result) => {
+				assert.equal(err, null);
+				assert(Array.isArray(result.topics));
+				// Make sure there are no tag brackets in the content
+				assert(result.topics.every(topic => topic instanceof Object && !/<.*?>/.test(topic.content)));
+
+				done();
+			});
+		});
 	});
 
 	describe('Categories.moveRecentReplies', () => {


### PR DESCRIPTION
Resolves #13, #15, #18, #19

# What?
Implemented search based on the content of a topic post in addition to the topic. The topics now display a short 100 character snippet of the content when there is a match to the query. This search bar appears in any of the categories.

# Why?
Adding the ability to search for posts reduces the potential for duplicated posts, allowing students to easily find similar questions before creating a new topic. Additionally, this can help users search for posts not only based on title, but also in the post body to allow searching for more detailed text.

# How?
1. Added a content field in `src/categories/topics.js` to each of the topics when `getCategoryTopics` is called to make sure the content is accessible in the frontend.
2. Added logic to `public/src/client/category.js` in `handleTopicSearch` to search based on the hidden post content. 
3. Added logic to `public/src/client/category.js` in `handleTopicSearch` to inject `html` to show the 100 character snippet when the query is matched by some topic content.

# Testing?
Added tests in `test/categories.js` for `getCategoryTopics` tests to make sure the categories have a content field, and the content field has no `html`. See UserGuide.md for user testing guide.

# Screenshots

https://github.com/user-attachments/assets/595c0edf-d6e2-44a0-8d44-3805854dd7ea

# Anything else?
Note: coverage in files that were not changed decreased slightly, but were not changed by our code.

Future changes: allow searching based on responses to a topic as well, not just the main post content. This would require more extensive backend changes to filter the topics before they are loaded into the topic. A better system for highlighting such as adding a style class would be effective in highlighting where search terms can be found in the titles/content.