### PR TITLE
Endorse: Created unit tests to test the functionality of the endorsement feature

### DIFF
--- a/test/topics.js
+++ b/test/topics.js
@@ -2504,6 +2504,40 @@ describe('Topic\'s', () => {
 			assert(!score);
 		});
 	});
+
+	describe('Endorsing', () => {
+		let tid;
+		let pid;
+		before(async () => {
+			// Create a new topic and post
+			const result = await topics.post({
+				uid: fooUid,
+				title: 'Test Topic for Upvoting',
+				content: 'This is a topic to test upvoting functionality',
+				cid: topic.categoryId,
+			});
+			tid = result.topicData.tid;
+			pid = result.postData.pid;
+		});
+
+		it('should endorse the post when an admin upvotes', async () => {
+			// Admin upvotes the post
+			await posts.upvote(pid, adminUid);
+
+			// Check if the post was upvoted
+			const voteData = await posts.getVoteStatusByPostIDs([pid], fooUid);
+			assert.strictEqual(voteData.showendorse[0], true, 'Post should be endorsed by admin');
+		});
+
+		it('should remove endorsement when admin removes upvote', async () => {
+			// Admin removes upvote
+			await posts.downvote(pid, adminUid);
+
+			// Check if the upvote and endorsement were removed
+			const voteData = await posts.getVoteStatusByPostIDs([pid], fooUid);
+			assert.strictEqual(voteData.showendorse[0], false, 'Post should not be endorsed by admin');
+		});
+	});
 });
 
 describe('Topics\'', async () => {

--- a/test/topics.js
+++ b/test/topics.js
@@ -2537,6 +2537,30 @@ describe('Topic\'s', () => {
 			const voteData = await posts.getVoteStatusByPostIDs([pid], fooUid);
 			assert.strictEqual(voteData.showendorse[0], false, 'Post should not be endorsed by admin');
 		});
+
+		it('should not endorse the post when a non-admin upvotes', async () => {
+			// Create a new user
+			const fooUid2 = await User.create({ username: 'foo2' });
+			// Random user upovtes the post
+			await posts.upvote(pid, fooUid2);
+
+
+			// Check if the post was upvoted
+			const voteData = await posts.getVoteStatusByPostIDs([pid], fooUid);
+			assert.strictEqual(voteData.showendorse[0], false, 'Post should not be endorsed by non-admin');
+		});
+
+		it('should not endorse the post when a non-admin removes an upvote', async () => {
+			// Create a new user
+			const fooUid2 = await User.create({ username: 'foo2' });
+			// Random user upovtes the post
+			await posts.downvote(pid, fooUid2);
+
+
+			// Check if post was not upovted
+			const voteData = await posts.getVoteStatusByPostIDs([pid], fooUid);
+			assert.strictEqual(voteData.showendorse[0], false, 'Post should not be endorsed by non-admin');
+		});
 	});
 });
 


### PR DESCRIPTION
# WHAT
Unit tests were added to ensure that when an admin upvotes a post, the post is then endorsed. Also included tests to ensure that when non-admins upvote a test that it is not endorsed.

# WHY
These tests ensure that the endorse function works as intended and is not hard coded for all posts.

Resolves: #23 

# HOW
We tested both admin and non-admin upvoting and down voting to make sure the proper values were passed and presented.

# Tests
![image](https://github.com/user-attachments/assets/d121ab49-5603-44f3-889c-a19db846f367)
