### PR TITLE
Adding frontend repo installation to azure-deploy-f24.yml

### DIFF
--- a/.github/workflows/azure-deploy-f24.yml
+++ b/.github/workflows/azure-deploy-f24.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           node-version: '20.17.0'
 
+      - name: Install frontend repo
+        run: |
+          npm install https://github.com/CMU-313/nodebb-frontend-f24-codebb.git
+
       - name: Set up NodeBB
         run: |
           ./nodebb setup '{"url":"nodebb-codebb.azurewebsites.net:443",


### PR DESCRIPTION
# What?
Adding installation of the Codebb frontend repository to propagate search bar and endorsement changes to the deployed Azure WebApp. Specifically installed using the Github link as per Emma Tong's instructions in Slack.

# Why?
Per the feedback from Emma Tong, cloning the codebase then npm install did not work properly; instead, running npm install on the github link will allow the frontend repository to be added.

# How?
Inserted lines 35 to 38 for running npm install.

# Problems:
Build fails when npm install is run before ./nodebb setup. See #32 for resolution.