### PR TITLE
Moving install frontend step after nodebb setup in azure-deploy-f24.yml

### DIFF
--- a/.github/workflows/azure-deploy-f24.yml
+++ b/.github/workflows/azure-deploy-f24.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           node-version: '20.17.0'
 
-      - name: Install frontend repo
-        run: |
-          npm install https://github.com/CMU-313/nodebb-frontend-f24-codebb.git
-
       - name: Set up NodeBB
         run: |
           ./nodebb setup '{"url":"nodebb-codebb.azurewebsites.net:443",
@@ -47,6 +43,10 @@ jobs:
             "redis:host": "${{ secrets.REDIS_HOST }}",
             "redis:port": "6379",
             "redis:password": "${{ secrets.REDIS_PASSWORD }}" }'
+      
+      - name: Install frontend repo
+        run: |
+          npm install https://github.com/CMU-313/nodebb-frontend-f24-codebb.git
           
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp


### PR DESCRIPTION
# What?
Moved install frontend step after the ./nodebb setup call as per Emma Tong's feedback on Slack. 

# Why?
Installing frontend before the ./nodebb setup call causes the build process to fail. Following the feedback from Emma Tong on Slack, moved the installation after the setup.

# How?
Moved from line 35 to 46, which comes after the "Set up NodeBB" step.

# Screenshots?
Deployed search and endorsement:
<img width="1067" alt="IMG_4279" src="https://github.com/user-attachments/assets/cd73827a-ce92-4e0a-8976-74f1c6aea208">
<img width="1378" alt="IMG_9414" src="https://github.com/user-attachments/assets/dece3802-6714-45b7-9125-ea06e11db065">


